### PR TITLE
Use os.path.basename

### DIFF
--- a/droopy
+++ b/droopy
@@ -81,9 +81,6 @@ else:
 import cgi
 import os
 import os.path
-import posixpath
-import macpath
-import ntpath
 import argparse
 import mimetypes
 import shutil
@@ -114,9 +111,7 @@ def fullpath(path):
 
 def basename(path):
     "Extract the file base name (some browsers send the full file path)."
-    for mod in posixpath, macpath, ntpath:
-        path = mod.basename(path)
-    return path
+    return os.path.basename(path)
 
 def check_auth(method):
     "Wraps methods on the request handler to require simple auth checks."


### PR DESCRIPTION
For macpath has been removed in python 3.8